### PR TITLE
return to page 0 when filtering 

### DIFF
--- a/src/js/data/mixins/Paging.js
+++ b/src/js/data/mixins/Paging.js
@@ -112,7 +112,7 @@ Fancy.Mixin('Fancy.store.mixin.Paging',{
       me.pages = Math.ceil(me.getTotal() / me.pageSize);
       if(!isNaN(oldPages) && oldPages > me.pages){
         //me.showPage--;
-        me.showPage = Math.floor((me.getTotal()/me.pageSize));
+        me.showPage = 0;
         if(me.showPage < 0){
           me.showPage = 0;
         }


### PR DESCRIPTION
When we were putting some filters, the grid was sending us to the last page. Default behaviour should be to the first page.